### PR TITLE
js: update combobox overlay to use SDRedirectDialog's rather than default

### DIFF
--- a/src/modules/ext.searchdigest.redirect.js
+++ b/src/modules/ext.searchdigest.redirect.js
@@ -35,7 +35,7 @@ SDRedirectDialog.prototype.initialize = function () {
   this.comboBox = new OO.ui.ComboBoxInputWidget( {
     value: '',
     options: [],
-    $overlay: true,
+    $overlay: this.$overlay,
     placeholder: mw.message('searchdigest-redirect-inputplaceholder').escaped()
   } );
   this.content.$element.append( '<p>' + mw.message('searchdigest-redirect-helptext').text() + '</p>' );


### PR DESCRIPTION
since SDRedirectDialog is a modal, trying to use the default overlay will cause its contents to be uninteractable since OOUI will "isolate" everything that isn't contained within the modal's window manager.

basically, follow the instructions at [https://www.mediawiki.org/wiki/OOUI/Concepts#Overlays](https://www.mediawiki.org/wiki/OOUI/Concepts#Overlays):
> For elements inside dialogs, you should use the dialog's `this.$overlay` property. 