### PR TITLE
Ensure alpha chars following first colon in page title are uppercase

### DIFF
--- a/src/modules/ext.searchdigest.redirect.js
+++ b/src/modules/ext.searchdigest.redirect.js
@@ -94,7 +94,11 @@ SDRedirectDialog.prototype.getSetupProcess = function ( data ) {
   data = data || {};
   return SDRedirectDialog.super.prototype.getSetupProcess.call( this, data )
       .next( function () {
-        this.pageToCreate = data.page;
+        // In many places, MediaWiki enforces uppercase alphas following the first colon;
+        // using a lowercase in page creation via the API can result in a hard-to-reach page.
+        // Since the former would resolve correctly even if the latter is searched,
+        // it is better to ensure that any character following a colon that can be UC'd, is.
+        this.pageToCreate = data.page.replace( /:./, x => x.toLocaleUpperCase( mw.config.get( "wgContentLanguage" ) ) );
         this.$content.find('#sd-ptc').text(data.page);
         this.actions.setAbilities( {
           redirect: false


### PR DESCRIPTION
As referenced in [a message](https://discord.com/channels/177206626514632704/538012741445615616/1236377092002807968) in #wiki-tech on the RS Wikis Discord, creating pages via the API with lowercase characters following the first colon in a page title can be problematic. It's difficult to navigate to them, view their history, edit them, or even delete them because MediaWiki tries its best to automatically convert such characters to uppercase.

Since a search for such a (malformed?) title, such as [RuneScape:user help](https://runescape.wiki/?title=Special%3ASearch&search=RuneScape%3Auser%20help) will instead be interpreted as "RuneScape:User help", it seems better to ensure these redirects are created with the much more accessible uppercase transformation already applied.